### PR TITLE
Fix typo in TelegramBotInitializer Javadoc

### DIFF
--- a/src/main/java/com/bot/telegram/config/TelegramBotInitializer.java
+++ b/src/main/java/com/bot/telegram/config/TelegramBotInitializer.java
@@ -11,7 +11,7 @@ import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
 import org.telegram.telegrambots.updatesreceivers.DefaultBotSession;
 
 /**
- * Clas to initialize the Telegram Bot
+ * Class to initialize the Telegram Bot
  */
 
 @Slf4j


### PR DESCRIPTION
## Summary
- correct typo in TelegramBotInitializer Javadoc

## Testing
- `./mvnw -q test` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6888e07c7dbc832b90d19b842c515d8f